### PR TITLE
Fix cropped views when UICollectionView updates

### DIFF
--- a/OLEContainerScrollView/OLEContainerScrollView+Swizzling.m
+++ b/OLEContainerScrollView/OLEContainerScrollView+Swizzling.m
@@ -29,7 +29,13 @@ void swizzleUICollectionViewLayoutFinalizeCollectionViewUpdates()
         // If we don't do this, the collection view will set its new content size only after the cell update animations
         // have finished, which is too late for us.
         UICollectionView *collectionView = _self.collectionView;
-        BOOL collectionViewIsInsideOLEContainerScrollView = [collectionView.superview isKindOfClass:[OLEContainerScrollViewContentView class]];
+
+        // In the case of a wrapped collection (case 2 in -[OLEContainerScrollView layoutSubviews]),
+        // we need to check up one extra level
+        BOOL collectionViewIsInsideOLEContainerScrollView =
+            [collectionView.superview isKindOfClass:[OLEContainerScrollViewContentView class]]
+            || [collectionView.superview.superview isKindOfClass:[OLEContainerScrollViewContentView class]];
+
         if (collectionViewIsInsideOLEContainerScrollView) {
             collectionView.contentSize = _self.collectionViewContentSize;
         }

--- a/OLEContainerScrollView/OLEContainerScrollView.m
+++ b/OLEContainerScrollView/OLEContainerScrollView.m
@@ -72,7 +72,6 @@
     NSParameterAssert(subview != nil);
 
     subview.autoresizingMask = UIViewAutoresizingNone;
-    subview.translatesAutoresizingMaskIntoConstraints = NO;
 
     [self.subviewsInLayoutOrder addObject:subview];
 


### PR DESCRIPTION
c789a48 needs a counterpart to properly react to `contentSize` changes in a wrapped `UICollectionView`.

Once this is working, some funny animations are revealed, which are fixed by a commit on master. I cherry picked it to minimize possible regressions.

@oettam 
